### PR TITLE
Fix bundling warnings by standardizing import patterns

### DIFF
--- a/src/background/modules/network-processor.module.ts
+++ b/src/background/modules/network-processor.module.ts
@@ -12,6 +12,7 @@ import { TokenTrackerModule } from './token-tracker.module';
 import { EnvironmentStorageManager } from '../environment-storage-manager';
 import { UnifiedPermissionService } from '../services/unified-permission-service';
 import { LibraryDetector } from '../utils/library-detector';
+import { unifiedPermissionManager } from '../../utils/unified-permission-manager';
 import {
   NetworkRequestData,
   SafetyConfig
@@ -846,9 +847,7 @@ export class NetworkProcessorModule {
       const tabId = validatedRequestData.tabId;
 
       if (tabId) {
-        // Import the unified permission manager directly
-        const { unifiedPermissionManager } = await import('../../utils/unified-permission-manager');
-
+        // Use the already imported unified permission manager
         // SECURITY FIX: Ensure permission manager is properly initialized before checking
         // This prevents library detection during Chrome startup when permissions aren't loaded
         const isReady = await unifiedPermissionManager.isReady();

--- a/src/background/shared/message-router-simple.module.ts
+++ b/src/background/shared/message-router-simple.module.ts
@@ -395,9 +395,7 @@ export class MessageRouterSimpleModule {
             }
 
             if (tabId !== undefined) {
-              // Import unified permission manager dynamically
-              const { unifiedPermissionManager } = await import('../../utils/unified-permission-manager');
-
+              // Use the already imported unified permission manager
               // Check if any of the three logging types are enabled for this tab
               const [networkEnabled, consoleEnabled, tokenEnabled] = await Promise.all([
                 unifiedPermissionManager.isFeatureEnabled(tabId, 'network'),


### PR DESCRIPTION
- Convert mixed static/dynamic imports to consistent static imports
- Remove dynamic imports from message-router-simple.module.ts and network-processor.module.ts
- Eliminates Vite bundler warnings about unified-permission-manager.ts
- No performance impact as all modules are instantiated at startup
- Improves code consistency and maintainability